### PR TITLE
chore: add .langgraph_api to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+.langgraph_api/


### PR DESCRIPTION
## Add .langgraph_api/ to .gitignore

### Problem

The LangGraph CLI creates a `.langgraph_api/` directory when running `langgraph dev` to store local server cache and state. In theory this directory should not be committed to version control as it contains local development artifacts.

### Testing

- ✅ Verified `.langgraph_api/` directory is created when running `uv run langgraph dev`
- ✅ Verified gitignore entry prevents the directory from being tracked

### Impact

Prevents local LangGraph cache files from being accidentally committed to the repository, keeping the repo clean and avoiding unnecessary cache files in version control.

